### PR TITLE
fix(ci): typing for ProgressService to unblock build

### DIFF
--- a/packages/core/src/progress/ProgressService.ts
+++ b/packages/core/src/progress/ProgressService.ts
@@ -1,5 +1,6 @@
 import { CheckpointStatus, PrismaClient } from '@prisma/client';
 import { getPrismaClient } from '../utils/prismaClient.js';
+import type { Checkpoint, User } from '../types.js';
 
 const DEFAULT_STATUS: CheckpointStatus = 'IN_PROGRESS';
 
@@ -46,22 +47,106 @@ export class ProgressService {
     this.prisma = prismaClient;
   }
 
+  private static isUser(value: unknown): value is User {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      'id' in value &&
+      typeof (value as { id: unknown }).id === 'string' &&
+      (!('email' in value) || typeof (value as { email?: unknown }).email === 'string' || (value as { email?: unknown }).email === undefined) &&
+      (!('name' in value) || typeof (value as { name?: unknown }).name === 'string' || (value as { name?: unknown }).name === undefined)
+    );
+  }
+
+  private static isConcept(value: unknown): value is { id: string; slug: string } {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      'id' in value &&
+      typeof (value as { id: unknown }).id === 'string' &&
+      'slug' in value &&
+      typeof (value as { slug: unknown }).slug === 'string'
+    );
+  }
+
+  private static isCheckpointWithConcept(
+    value: unknown
+  ): value is Omit<Checkpoint, 'concept'> & {
+    concept: { slug: string };
+    status: CheckpointStatus;
+    updatedAt: Date;
+  } {
+    if (typeof value !== 'object' || value === null) {
+      return false;
+    }
+
+    const record = value as Record<string, unknown>;
+    const concept = record.concept as Record<string, unknown> | undefined;
+
+    return (
+      typeof record.id === 'string' &&
+      typeof record.userId === 'string' &&
+      record.createdAt instanceof Date &&
+      record.updatedAt instanceof Date &&
+      typeof record.status === 'string' &&
+      typeof concept === 'object' &&
+      concept !== null &&
+      typeof (concept as { slug?: unknown }).slug === 'string'
+    );
+  }
+
+  private static isUserWithCheckpoints(
+    value: unknown
+  ): value is User & {
+    checkpoints?: Array<
+      Omit<Checkpoint, 'concept'> & {
+        concept: { slug: string };
+        status: CheckpointStatus;
+        updatedAt: Date;
+      }
+    >;
+  } {
+    if (!ProgressService.isUser(value)) {
+      return false;
+    }
+
+    const record = value as unknown as Record<string, unknown>;
+
+    if (!('checkpoints' in record)) {
+      return true;
+    }
+
+    const checkpoints = record.checkpoints;
+    return (
+      checkpoints === undefined ||
+      (Array.isArray(checkpoints) && checkpoints.every(ProgressService.isCheckpointWithConcept))
+    );
+  }
+
   /** Ensures a user record exists for the given email. */
-  async ensureUser(email: string, name?: string) {
-    return this.prisma.user.upsert({
+  async ensureUser(email: string, name?: string): Promise<User> {
+    const result = await this.prisma.user.upsert({
       where: { email },
       update: { name },
       create: { email, name }
     });
+    if (!ProgressService.isUser(result)) {
+      throw new TypeError('Invalid user payload received from Prisma');
+    }
+    return result;
   }
 
   /** Ensures a concept record exists and returns it. */
-  async ensureConcept(input: EnsureConceptInput) {
-    return this.prisma.concept.upsert({
+  async ensureConcept(input: EnsureConceptInput): Promise<{ id: string; slug: string }> {
+    const concept = await this.prisma.concept.upsert({
       where: { slug: input.slug },
       update: { title: input.title, description: input.description },
       create: { slug: input.slug, title: input.title, description: input.description }
     });
+    if (!ProgressService.isConcept(concept)) {
+      throw new TypeError('Invalid concept payload received from Prisma');
+    }
+    return concept;
   }
 
   /** Records a checkpoint update for a user and concept. */
@@ -91,16 +176,11 @@ export class ProgressService {
       }
     });
 
-    if (!user) {
+    if (!user || !ProgressService.isUserWithCheckpoints(user)) {
       return { checkpoints: [] };
     }
 
-    const checkpoints = (user.checkpoints as Array<{
-      id: string;
-      concept: { slug: string };
-      status: CheckpointStatus;
-      updatedAt: Date;
-    }> | undefined) ?? [];
+    const checkpoints = user.checkpoints ?? [];
 
     return {
       checkpoints: checkpoints.map((checkpoint) => ({
@@ -115,9 +195,10 @@ export class ProgressService {
   /** Starts a tutoring session and returns its ID. */
   async startSession(input: StartSessionInput) {
     const user = await this.ensureUser(input.userEmail);
-    const concept = input.conceptSlug
+    const conceptRecord = input.conceptSlug
       ? await this.prisma.concept.findUnique({ where: { slug: input.conceptSlug } })
       : null;
+    const concept = conceptRecord && ProgressService.isConcept(conceptRecord) ? conceptRecord : null;
 
     return this.prisma.session.create({
       data: {

--- a/packages/core/src/progress/__tests__/ProgressService.test.ts
+++ b/packages/core/src/progress/__tests__/ProgressService.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { CheckpointStatus, PrismaClient } from '@prisma/client';
+import { ProgressService } from '../ProgressService.js';
+
+const baseUser = {
+  id: 'user-1',
+  email: 'user@example.com',
+  name: 'Test User'
+};
+
+const baseConcept = {
+  id: 'concept-1',
+  slug: 'algebra-basics',
+  title: 'Algebra Basics',
+  description: 'Intro'
+};
+
+const now = new Date();
+const inProgress: CheckpointStatus = 'IN_PROGRESS';
+
+const prismaMock: Partial<PrismaClient> = {
+  user: {
+    upsert: vi.fn().mockResolvedValue(baseUser),
+    findUnique: vi.fn().mockResolvedValue({
+      ...baseUser,
+      checkpoints: [
+        {
+          id: 'checkpoint-1',
+          concept: { slug: baseConcept.slug },
+          userId: baseUser.id,
+          createdAt: now,
+          updatedAt: now,
+          status: inProgress
+        }
+      ]
+    })
+  },
+  concept: {
+    upsert: vi.fn().mockResolvedValue(baseConcept),
+    findUnique: vi.fn().mockResolvedValue(baseConcept)
+  },
+  checkpoint: {
+    create: vi.fn().mockResolvedValue({ id: 'checkpoint-1' })
+  },
+  session: {
+    create: vi.fn().mockResolvedValue({ id: 'session-1', userId: baseUser.id, conceptId: baseConcept.id }),
+    update: vi.fn()
+  }
+};
+
+describe('ProgressService typing', () => {
+  it('accepts valid user and concept inputs', async () => {
+    const service = new ProgressService(prismaMock as PrismaClient);
+
+    await service.recordCheckpoint({
+      userEmail: baseUser.email,
+      userName: baseUser.name,
+      concept: {
+        slug: baseConcept.slug,
+        title: baseConcept.title,
+        description: baseConcept.description
+      },
+      status: inProgress
+    });
+
+    const summary = await service.getUserSummary(baseUser.email);
+    expect(summary.checkpoints[0]?.conceptSlug).toBe(baseConcept.slug);
+  });
+});

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,0 +1,12 @@
+export interface User {
+  id: string;
+  email?: string;
+  name?: string;
+}
+
+export interface Checkpoint {
+  id: string;
+  concept: string;
+  userId: string;
+  createdAt: Date;
+}


### PR DESCRIPTION
## Summary
- add explicit User and Checkpoint interfaces so ProgressService can rely on typed ids/concepts
- layer runtime type guards to validate prisma payloads before use and prevent `unknown`/`{}` access
- include a minimal Vitest to exercise the service with a typed user/concept pair

## Testing
- pnpm build
- pnpm test

## Notes
- Root cause: strict TypeScript settings treated prisma responses as `unknown`/`{}`, so `user.id` and related fields failed compilation.
- Fix: introduce shared interfaces plus defensive guards in ProgressService to assert payload shapes before usage.
- Trade-offs: adds light runtime checks that throw if prisma returns unexpected data, which keeps type safety at the cost of minimal overhead.

## Questions
- Are you comfortable with the new runtime guards throwing if prisma returns unexpected shapes?


------
https://chatgpt.com/codex/tasks/task_e_68cdfcbef2f083208340a68f1931b802