### PR TITLE
fix: mock prisma client in progress service test

### DIFF
--- a/packages/core/src/progress/__tests__/ProgressService.test.ts
+++ b/packages/core/src/progress/__tests__/ProgressService.test.ts
@@ -1,4 +1,21 @@
-import { describe, expect, it, vi } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
+
+vi.mock('@prisma/client', () => {
+  class PrismaClient {
+    checkpoint = {
+      create: vi.fn(async (args?: any) => ({
+        id: 'cp_1',
+        concept: args?.data?.concept ?? 'demo',
+        userId: 'u1',
+        createdAt: new Date()
+      })),
+      findMany: vi.fn(async () => [])
+    };
+  }
+  return { PrismaClient };
+});
+
+// now import the code under test
 import type { CheckpointStatus, PrismaClient } from '@prisma/client';
 import { ProgressService } from '../ProgressService.js';
 


### PR DESCRIPTION
## Summary
- add a Vitest mock for `@prisma/client` in the progress service test
- ensure the test uses the mocked client before importing the code under test to avoid runtime module resolution errors

## Testing
- pnpm --filter @ai-2dor/core test

## Reasoning
The mock replaces the runtime Prisma dependency that is not available during Vitest runs, allowing the progress tests to execute against controlled stubbed methods.

## Trade-offs
The mock currently exposes only the checkpoint methods needed by the tests; expanding coverage may require extending the stub if additional Prisma interactions are added later.

## Questions
- Should we extend this pattern to other tests that exercise Prisma interactions as well?


------
https://chatgpt.com/codex/tasks/task_e_68ce0f6b608c8320a08920627f7fa07b