### PR TITLE
fix(ci): lazy Prisma client + type-only imports to unblock Vitest

### DIFF
--- a/packages/core/src/progress/ProgressService.ts
+++ b/packages/core/src/progress/ProgressService.ts
@@ -1,4 +1,4 @@
-import { CheckpointStatus, PrismaClient } from '@prisma/client';
+import type { CheckpointStatus, PrismaClient } from '@prisma/client';
 import { getPrismaClient } from '../utils/prismaClient.js';
 import type { Checkpoint, User } from '../types.js';
 


### PR DESCRIPTION
- Use type-only imports for Prisma symbols to avoid runtime loading during tests
- Add createRequire-based lazy loader with safe no-op fallback when @prisma/client isn't generated
- No runtime behavior changes outside tests
- Expect CI to pass lint + tests